### PR TITLE
Fix use of dark names for simple push

### DIFF
--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -125,7 +125,8 @@ jobs:
         description: The Cloud Foundry manifest for this environment
       package:
         type: string
-        description: path to the package/files to push
+        description: path to the package/files to push if not the current directory
+        default: ""
     steps:
       - checkout
       - when:
@@ -281,7 +282,7 @@ jobs:
           org: <<parameters.org>>
           space: <<parameters.space>>
       - dark_deploy:
-          appname: <<parameters.appname>>
+          appname: <<parameters.appname>>-dark
           manifest: <<parameters.manifest>>
           package: <<parameters.package>>
           domain: <<parameters.domain>>
@@ -374,17 +375,18 @@ commands:
       package:
         type: string
         description: path to the asset/package to push
+        default: ""
     steps:
       - run:
           name: Cloud Foundry Push
           command: |
             #push no start so we can set envars
-            cf push --no-start <<parameters.appname>> -f <<parameters.manifest>> -p <<parameters.package>>
-            cf set-env <<parameters.appname>>-dark CIRCLE_BUILD_NUM ${CIRCLE_BUILD_NUM}
-            cf set-env <<parameters.appname>>-dark CIRCLE_SHA1 ${CIRCLE_SHA1}
-            cf set-env <<parameters.appname>>-dark CIRCLE_WORKFLOW_ID ${CIRCLE_WORKFLOW_ID}
-            cf set-env <<parameters.appname>>-dark CIRCLE_PROJECT_USERNAME ${CIRCLE_PROJECT_USERNAME}
-            cf set-env <<parameters.appname>>-dark CIRCLE_PROJECT_REPONAME ${CIRCLE_PROJECT_REPONAME}
+            cf push --no-start <<parameters.appname>> -f <<parameters.manifest>> <<# parameters.package>> -p <<parameters.package>> <</ parameters.package>>
+            cf set-env <<parameters.appname>> CIRCLE_BUILD_NUM ${CIRCLE_BUILD_NUM}
+            cf set-env <<parameters.appname>> CIRCLE_SHA1 ${CIRCLE_SHA1}
+            cf set-env <<parameters.appname>> CIRCLE_WORKFLOW_ID ${CIRCLE_WORKFLOW_ID}
+            cf set-env <<parameters.appname>> CIRCLE_PROJECT_USERNAME ${CIRCLE_PROJECT_USERNAME}
+            cf set-env <<parameters.appname>> CIRCLE_PROJECT_REPONAME ${CIRCLE_PROJECT_REPONAME}
             #now start
             cf start <<parameters.appname>>
 

--- a/test/bats_helper.bash
+++ b/test/bats_helper.bash
@@ -86,5 +86,13 @@ function assert_jq_match {
 	fi
 }
 
+function assert_jq_contains {
+	MATCH=$2
+	RES=$(jq -r "$1" ${JSON_PROJECT_CONFIG})
+	if [[ "$RES" != *"$MATCH"* ]];then
+		echo "Expected match "'"'"$MATCH"'"'" was not found in "'"'"$RES"'"'
+		return 1
+	fi
+}
 
 

--- a/test/test_expansion.bats
+++ b/test/test_expansion.bats
@@ -66,11 +66,26 @@ function setup {
 
 }
 
+@test "Job: simple push respects appname" {
+  # given
+  process_config_with test/inputs/job-push.yml
 
+  # when
+  assert_jq_match '.jobs | length' 1
+  assert_jq_match '.jobs["cloudfoundry/push"].steps | length' 4
+  assert_jq_match '.jobs["cloudfoundry/push"].steps[3].run.name' 'Cloud Foundry Push'
+  assert_jq_contains '.jobs["cloudfoundry/push"].steps[3].run.command' 'cf set-env blueskygreenbuilds CIRCLE_BUILD_NUM ${CIRCLE_BUILD_NUM}'
 
+}
 
+@test "Job: BlueGreen push uses dark appname" {
+  # given
+  process_config_with test/inputs/jobs-merged.yml
 
+  # when
+  assert_jq_match '.jobs | length' 1
+  assert_jq_match '.jobs["cloudfoundry/blue_green"].steps | length' 5
+  assert_jq_match '.jobs["cloudfoundry/blue_green"].steps[3].run.name' 'Cloud Foundry Dark Deployment'
+  assert_jq_contains '.jobs["cloudfoundry/blue_green"].steps[3].run.command' 'cf set-env blueskygreenbuilds-dark CIRCLE_BUILD_NUM ${CIRCLE_BUILD_NUM}'
 
-
-
-
+}


### PR DESCRIPTION
Found  bug in which use of simple push job assumed an app name for blue/green deployments.

Also added additional tests to prevent regression.