### PR TITLE
Don't include subdomain in commands when blank

### DIFF
--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -413,7 +413,7 @@ commands:
       - run:
           name: Cloud Foundry Dark Deployment
           command: |
-            cf push --no-start "<<parameters.appname>>-dark" -f "<<parameters.manifest>>" -p "<<parameters.package>>" -n "<<parameters.dark_subdomain>>" -d "<<parameters.domain>>"
+            cf push --no-start "<<parameters.appname>>-dark" -f "<<parameters.manifest>>" -p "<<parameters.package>>"<<# parameters.dark_subdomain>> -n "<<parameters.dark_subdomain>>"<</ parameters.dark_subdomain>> -d "<<parameters.domain>>"
             cf set-env "<<parameters.appname>>-dark" CIRCLE_BUILD_NUM "${CIRCLE_BUILD_NUM}"
             cf set-env "<<parameters.appname>>-dark" CIRCLE_SHA1 "${CIRCLE_SHA1}"
             cf set-env "<<parameters.appname>>-dark" CIRCLE_WORKFLOW_ID "${CIRCLE_WORKFLOW_ID}"
@@ -423,7 +423,7 @@ commands:
             # Push as "dark" instance (URL in manifest)
             cf start "<<parameters.appname>>-dark"
             # Ensure dark route is exclusive to dark app
-            cf unmap-route "<<parameters.appname>>" "<<parameters.domain>>" -n "<<parameters.dark_subdomain>>" || echo "Already exclusive"
+            cf unmap-route "<<parameters.appname>>" "<<parameters.domain>>"<<# parameters.dark_subdomain>> -n "<<parameters.dark_subdomain>>"<</ parameters.dark_subdomain>> || echo "Already exclusive"
 
 
   live_deploy:
@@ -443,9 +443,9 @@ commands:
           name: Cloud Foundry - Re-route live Domain
           command: |
             # Send "real" url to new version
-            cf map-route "<<parameters.appname>>-dark" "<<parameters.domain>>" -n "<<parameters.live_subdomain>>"
+            cf map-route "<<parameters.appname>>-dark" "<<parameters.domain>>"<<# parameters.live_subdomain>> -n "<<parameters.live_subdomain>>"<</ parameters.live_subdomain>>
             # Stop sending traffic to previous version
-            cf unmap-route "<<parameters.appname>>" "<<parameters.domain>>" -n "<<parameters.live_subdomain>>"
+            cf unmap-route "<<parameters.appname>>" "<<parameters.domain>>"<<# parameters.live_subdomain>> -n "<<parameters.live_subdomain>>"<</ parameters.live_subdomain>>
             # stop previous version
             cf stop "<<parameters.appname>>"
             # delete previous version

--- a/test/bats_helper.bash
+++ b/test/bats_helper.bash
@@ -95,4 +95,11 @@ function assert_jq_contains {
 	fi
 }
 
-
+function assert_jq_not_contains {
+	MATCH=$2
+	RES=$(jq -r "$1" ${JSON_PROJECT_CONFIG})
+	if [[ "$RES" == *"$MATCH"* ]];then
+		echo "Unexpected match "'"'"$MATCH"'"'" was found in "'"'"$RES"'"'
+		return 1
+	fi
+}

--- a/test/inputs/jobs-separate_no-subdomain.yml
+++ b/test/inputs/jobs-separate_no-subdomain.yml
@@ -1,0 +1,19 @@
+workflows:
+  version: 2
+  build-deploy:
+    jobs:
+      - cloudfoundry/dark_deploy:
+          appname: blueskygreenbuilds
+          org: eddies-org
+          space: circleci
+          workspace_path: /tmp
+          manifest: /tmp/cf-manifest.yml
+          package: /tmp/standalone-app.jar
+          domain: dark-blueskygreenbuilds.com
+          dark_subdomain: ''
+      - cloudfoundry/live_deploy:
+          appname: blueskygreenbuilds
+          org: eddies-org
+          space: circleci
+          domain: blueskygreenbuilds.com
+          live_subdomain: ''

--- a/test/test_expansion.bats
+++ b/test/test_expansion.bats
@@ -89,3 +89,15 @@ function setup {
   assert_jq_contains '.jobs["cloudfoundry/blue_green"].steps[3].run.command' 'cf set-env "blueskygreenbuilds-dark" CIRCLE_BUILD_NUM "${CIRCLE_BUILD_NUM}"'
 
 }
+
+@test "Job: blank subdomains are not in commands" {
+  # given
+  process_config_with test/inputs/jobs-separate_no-subdomain.yml
+
+  # when
+  assert_jq_contains '.jobs["cloudfoundry/dark_deploy"].steps[3].run.command' 'cf push --no-start "blueskygreenbuilds-dark" -f "/tmp/cf-manifest.yml" -p "/tmp/standalone-app.jar" -d "dark-blueskygreenbuilds.com"'
+  assert_jq_not_contains '.jobs["cloudfoundry/dark_deploy"].steps[3].run.command' ' -n '
+
+  assert_jq_not_contains '.jobs["cloudfoundry/live_deploy"].steps[1].run.command' ' -n '
+  assert_jq_not_contains '.jobs["cloudfoundry/live_deploy"].steps[1].run.command' ' -n '
+}


### PR DESCRIPTION
Users may not use a subdomain in their live and/or dark route. They could set the subdomain to blank before, but it would still be included in the command. This works as long as it is quoted, but it would be better to not include it at all.

---

See https://github.com/CircleCI-Public/cloudfoundry-orb/pull/7#issuecomment-473984805 for background

Note that all tests will not pass on this branch because it doesn't have the changes from #8.