### PR TITLE
Update examples

### DIFF
--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -12,10 +12,9 @@ examples:
       version: 2.1
 
       orbs:
-        cloudfoundry: circleci/cloudfoundry@1.0
+        cloudfoundry: circleci/cloudfoundry@x.y.z
 
       workflows:
-        version: 2
         build-deploy:
           jobs:
             - build
@@ -43,10 +42,9 @@ examples:
       version: 2.1
 
       orbs:
-        cloudfoundry: circleci/cloudfoundry@1.0
+        cloudfoundry: circleci/cloudfoundry@x.y.z
 
       workflows:
-        version: 2
         build-deploy:
           jobs:
             - cloudfoundry/push:
@@ -61,17 +59,17 @@ examples:
 
   blue_green_deploy:
     description: |
-      A blue-green deployment with a manual approval step
+      A blue-green deployment
     usage:
       version: 2.1
 
       orbs:
-        cloudfoundry: circleci/cloudfoundry@1.0
+        cloudfoundry: circleci/cloudfoundry@x.y.z
 
       workflows:
         build_deploy:
           jobs:
-            - cloudfoundry/dark_deploy:
+            - cloudfoundry/blue_green:
                 context: your-context
                 appname: your-app
                 org: your-org
@@ -79,20 +77,11 @@ examples:
                 build_steps:
                   - run: # your build steps
                   - run: # you can have more, too
+                validate_steps:
+                  - run: # your validation steps
+                  - run: # you can also have more of these
                 manifest: # path to manifest.yml file
                 package: # path to application package
-                domain: your-domain
-            - hold:
-                type: approval
-                requires:
-                  - cloudfoundry/dark_deploy
-            - cloudfoundry/live_deploy:
-                requires:
-                  - hold
-                context: your-context
-                appname: your-app
-                org: your-org
-                space: your-space
                 domain: your-domain
 
 jobs:

--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -52,8 +52,8 @@ examples:
                 org: your-org
                 space: your-space
                 build_steps:
-                  - run: # your build steps
-                  - run: # you can have more, too
+                  - run: echo 'your build steps'
+                  - run: echo 'you can have more, too'
                 manifest: # path to manifest.yml file
                 package: # path to application package
 
@@ -75,11 +75,11 @@ examples:
                 org: your-org
                 space: your-space
                 build_steps:
-                  - run: # your build steps
-                  - run: # you can have more, too
+                  - run: echo 'your build steps'
+                  - run: echo 'you can have more, too'
                 validate_steps:
-                  - run: # your validation steps
-                  - run: # you can also have more of these
+                  - run: echo 'your validation steps'
+                  - run: echo 'you can also have more of these'
                 manifest: # path to manifest.yml file
                 package: # path to application package
                 domain: your-domain

--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -12,7 +12,7 @@ examples:
       version: 2.1
 
       orbs:
-        cloudfoundry: circleci/cloudfoundry@x.y.z
+        cloudfoundry: circleci/cloudfoundry@x.y
 
       workflows:
         build-deploy:
@@ -42,7 +42,7 @@ examples:
       version: 2.1
 
       orbs:
-        cloudfoundry: circleci/cloudfoundry@x.y.z
+        cloudfoundry: circleci/cloudfoundry@x.y
 
       workflows:
         build-deploy:
@@ -64,7 +64,7 @@ examples:
       version: 2.1
 
       orbs:
-        cloudfoundry: circleci/cloudfoundry@x.y.z
+        cloudfoundry: circleci/cloudfoundry@x.y
 
       workflows:
         build_deploy:


### PR DESCRIPTION
- use all-in-one `blue_green` job instead of manual `dark_deploy` + `live_deploy` jobs
- fix orb versions in examples (`1.0` -> `x.y`)